### PR TITLE
Sprint C submission

### DIFF
--- a/submissions/sprint_a/Pipfile
+++ b/submissions/sprint_a/Pipfile
@@ -11,6 +11,7 @@ flask = "*"
 python-dotenv = "*"
 pytest = "*"
 pytest-flask = "*"
+flask-testing = "*"
 
 [requires]
 python_version = "3.7"

--- a/submissions/sprint_a/Pipfile.lock
+++ b/submissions/sprint_a/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d3e288d47cf5d6ec1be2c38b4d0032e13f14f17a5c935cbf721155e510827732"
+            "sha256": "27e86c975276c6db41072266d3c4bd0a76581e7e33fb1ee94d192c3ee7f3072f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -44,6 +44,13 @@
             ],
             "index": "pypi",
             "version": "==1.0.2"
+        },
+        "flask-testing": {
+            "hashes": [
+                "sha256:dc076623d7d850653a018cb64f500948334c8aeb6b10a5a842bf1bcfb98122bc"
+            ],
+            "index": "pypi",
+            "version": "==0.7.1"
         },
         "itsdangerous": {
             "hashes": [

--- a/submissions/sprint_a/README.md
+++ b/submissions/sprint_a/README.md
@@ -1,0 +1,11 @@
+# Epithet Generator
+Serves a randomly generated shakespearean insult from the vocab list at
+[Shakespeare Insult Kit](http://www.pangloss.com/seidel/shake_rule.html).
+
+## Usage
+Once you run the program, going to your '/' or root route will serve up one 
+randomly generated insult.
+
+The /vocabulary route will serve up a dictionary of all the words
+available to generate an insult.
+

--- a/submissions/sprint_a/app.py
+++ b/submissions/sprint_a/app.py
@@ -10,6 +10,19 @@ def generate_epithets():
     return flask.jsonify(EpithetGenerator.create_insult(json_path))
 
 
+@app.route('/epithets/<int:quantity>')
+def epithets_quantity(quantity):
+    quantity_list = []
+    for i in range(quantity):
+        quantity_list.append(EpithetGenerator.create_insult(json_path))
+    return flask.jsonify(quantity_list)
+
+
 @app.route('/vocabulary')
 def vocabulary():
     return flask.jsonify(EpithetGenerator.all_vocab(json_path))
+
+
+@app.route('/unleash_nemesis_rant')
+def nemesis_rant():
+    return flask.jsonify(EpithetGenerator.nemesis_rant(json_path))

--- a/submissions/sprint_a/helpers.py
+++ b/submissions/sprint_a/helpers.py
@@ -55,12 +55,28 @@ class EpithetGenerator:
         """Pulls one random word from each Column/Key and formats
         them into a phrase/string"""
         my_dict = Vocabulary.from_file(path, fields=False)
-        my_phrase = '{} {} {}'.format(random.choice(my_dict["Column 1"]),
-                                      random.choice(my_dict["Column 2"]),
-                                      random.choice(my_dict["Column 3"]))
+        my_phrase = 'Thou, {}, {}, {}'.format(
+            random.choice(my_dict["Column 1"]),
+            random.choice(my_dict["Column 2"]),
+            random.choice(my_dict["Column 3"]))
         return my_phrase
 
     def all_vocab(path):
-        """Returns json data from path"""
+        """Returns all json data from path"""
         my_dict = Vocabulary.from_file(path, fields=False)
         return my_dict
+
+    def nemesis_rant(path):
+        """Returns a random amount of epithets"""
+        my_dict = EpithetGenerator.all_vocab(path)
+        max_epithets = len(my_dict['Column 1'])
+        phrase_list = []
+        random_epithets_count = random.randint(1, max_epithets)
+        print(random_epithets_count)
+        for i in range(random_epithets_count):
+            my_phrase = 'Thou, {}, {}, {}'.format(
+                random.choice(my_dict["Column 1"]),
+                random.choice(my_dict["Column 2"]),
+                random.choice(my_dict["Column 3"]))
+            phrase_list.append(my_phrase)
+        return phrase_list

--- a/submissions/sprint_a/test_helpers.py
+++ b/submissions/sprint_a/test_helpers.py
@@ -21,7 +21,7 @@ def test_from_file():
 
 
 def test_create_insult():
-    assert len(EpithetGenerator.create_insult(json_path).split()) == 3
+    assert len(EpithetGenerator.create_insult(json_path).split()) == 4
 
 
 def test_all_vocab():

--- a/submissions/sprint_a/test_integration.py
+++ b/submissions/sprint_a/test_integration.py
@@ -1,0 +1,40 @@
+import pytest
+import json
+from .app import app
+from flask_testing import TestCase
+
+json_path = '../../resources/data.json'
+
+
+class BaseTest(TestCase):
+
+    def create_app(self):
+        app.config['TESTING'] = True
+        self.client = app.test_client()
+        return app
+
+
+class TestFileManager(BaseTest):
+
+    def test_root_path(self):
+        response = self.client.get("/")
+        data = response.data
+        assert len(data.split()) == 4
+
+    def test_quantity_path(self):
+        response = self.client.get('/epithets/5')
+        data = json.loads(response.data)
+        assert len(data) == 5
+
+    def test_vocab_path(self):
+        response = self.client.get("/vocabulary")
+        data = json.loads(response.data)
+        assert 'Column 1' in data
+        assert 'Column 2' in data
+        assert 'Column 3' in data
+
+    def test_nemesis_path(self):
+        response = self.client.get("/unleash_nemesis_rant")
+        data = json.loads(response.data)
+        assert data != 0
+        assert len(data[-1].split()) % 4 == 0

--- a/submissions/sprint_b/README.md
+++ b/submissions/sprint_b/README.md
@@ -1,0 +1,16 @@
+# Epithet Generator
+
+Serves a randomly generated shakespearean insult from the vocab list at
+[Shakespeare Insult Kit](http://www.pangloss.com/seidel/shake_rule.html).
+
+## Usage
+
+Once you run the program, going to your **/** or root route will serve up one
+randomly generated insult.
+
+The **/vocabulary** route will serve up a dictionary of all the words
+available to generate an insult.
+
+The **/epithets/<int:quantity>** route will serve up a user specified number
+of epithets with the value in the **< >**.
+An example would be going to **/epithets/8** would serve you 8 epithets.

--- a/submissions/sprint_c/README.md
+++ b/submissions/sprint_c/README.md
@@ -1,0 +1,19 @@
+# Epithet Generator
+
+Serves a randomly generated shakespearean insult from the vocab list at
+[Shakespeare Insult Kit](http://www.pangloss.com/seidel/shake_rule.html).
+
+## Usage
+
+Once you run the program, going to your **/** or root route will serve up one
+randomly generated insult.
+
+The **/vocabulary** route will serve up a dictionary of all the words
+available to generate an insult.
+
+The **/epithets/<int:quantity>** route will serve up a user specified number
+of epithets with the value provided inside the **< >** in the route.
+An example would be going to **/epithets/8** would serve you 8 epithets.
+
+The **/unleash_nemesis_rant** route will serve up a random amount of epithets
+with a limit based on how many words are in the dictionary.


### PR DESCRIPTION
Turning in Sprint C. In this submission I also included the READMEs I did not add in the previous sprint submissions. Sprint A, sprint b, and sprint c will all have READMEs in their respective folders, but only Sprint A has the updated working files for Sprint C. I also added the endpoint I neglected to see in Sprint B to specify the quantity of epithets.